### PR TITLE
fix: clean up build process and configure workspace settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-strict-peer-dependencies=false
-auto-install-peers=true

--- a/nx.json
+++ b/nx.json
@@ -24,7 +24,7 @@
     "sharedGlobals": []
   },
   "workspaceLayout": {
-    "appsDir": "packages",
+    "appsDir": "apps",
     "libsDir": "packages"
   }
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -10,6 +10,7 @@ const names = name.slice(1).split('/');
 
 export default defineConfig({
   build: {
+    emptyOutDir: true,
     lib: {
       entry,
       name: names[0],
@@ -18,6 +19,7 @@ export default defineConfig({
   },
   plugins: [dts({
     entryRoot: entry,
+    exclude: ['**/*.test.ts'],
   })],
   test: {
     environment: 'jsdom',

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+strictPeerDependencies: false
+autoInstallPeers: true


### PR DESCRIPTION
This PR moves `.npmrc` settings to `pnpm-workspace.yaml` (where they are standard and cleaner), removes `.npmrc`, corrects the generated core type definition files by excluding test files, and fixes Nx workspace layout directory settings.

---
*PR created automatically by Jules for task [10489557853780222869](https://jules.google.com/task/10489557853780222869) started by @EastSun5566*